### PR TITLE
RFC on changing the context object

### DIFF
--- a/rfc/2016-03-context.md
+++ b/rfc/2016-03-context.md
@@ -1,8 +1,6 @@
 # Summary
 
-The `context` object, while flexible, is a poor representation of the domain model of deployment. A topic-based `pub/sub` might prove more robust, as might implementing a strict domain model.
-
-More than proposing a definite solution, this should be seen literally as a request for comments.
+The `context` object, while flexible, is a poor representation of the domain model of deployment. A growing ecosystem calls for more guidance. This RFC introduces a stronger domain model, while still maintaining the original flexibility.
 
 # Background
 
@@ -10,30 +8,33 @@ The `ember-cli-deploy` project uses a pipeline to trigger their different stages
 
 Throughout the pipeline plugins read, write and share state through the so-called `context` object, a hash which can contain raw values and also functions. An example would be the `ember-cli-deploy-build` plugin, which in the `build` step compiles the container `ember-cli` project and writes the resulting array of files to `context.distFiles`. Other plugins then follow to upload those files to s3, Azure or other services.
 
-# Issues
+The ecosystem of plugins has grown to a total of 57 by now. They have dependencies on the information and information format put into the `context` object, plus the timing of the hooks. An informal domain model is less suited for a growing ecosystem. Implicit dependencies and decentralized decisions about plugin ordering makes maintaining the ecosystem challenging.
 
-An informal domain model is less suited for a growing ecosystem. Implicit dependencies and decentralized decisions about plugin ordering makes maintaining the ecosystem challanging.
+# Proposal
 
-The ecosystem of plugins has grown to a total of 57 by now. They have dependencies on the information and information format put into the `context` object, plus the timing of the hooks:
-- if `context.distFiles` would be renamed to `context.files`, all plugins that consume this information would need to be updated.
-- if `ember-cli-deploy-revision-data`, a plugin to generate a unique fingerprint for a build, were to move their pipeline hook from `didBuild` (running after `build`) to `prepare` (running between `build` and `upload`), any plugins in `didBuild` and `willPrepare`, before having access to this information, now do not.
+The `context` object itself should be immutable, the only modifications taking place with the return values from hooks. Verification of appropriateness of returned values would take place in `ember-cli-deploy`, possibly warning against deprecations, possibly linting return values.
 
-With the 57 plugins, many combinations of plugins are possible for a single deployment configuration. One might put together `build`, `revision-data`, `gzip`, `s3-index` and `sentry`. The `sentry` plugin edits `index.html` to add in the `revision-data` hash, so bugs in production can be attributed to the right version. Imagine `index.html` were also gzipped. Should `gzip` take place before or after adding the hash to `index.html`?
+Consuming values in the `context` object would be done by using wrapper functions, possibly in `ember-cli-deploy-base-plugin`, e.g.
 
-The `gzip` plugin enables other plugins to be quite agnostic about whether it ran its operation: all it does is replace the list of distFiles with a list of gzipped files. However, in some cases, the not yet compressed files are also required. Should the `gzip` plugin present this information side by side, or should the output of `build` and `gzip` be distinct, so that plugins could consume what suits them?
+```javascript
+readFiles: function() {
+  return context.distFiles;
+}
+```
 
-The plugin author of each plugin at the moment has to make sure that their plugin assumes the right position in ordering in respect to the other plugins. It is not hard to imagine a scenario where constraints in plugin ordering arise which cannot be satisfied (A depends on B, B depends on C, C depends on A) or a scenario where two use cases exist that require different plugin ordering.
+The possible functions are
 
-# Proposals
-
-1. If plugins emit what information they would want to consume (files, a minimatch pattern, revision hash, previous deployments) as subscribers on these topics, plus what they could produce as producers on these topics, an automated plugin ordering could be made, also removing the need for set hooks. Context information would be per-topic, passed into the function, instead of globally available.
-2. The `ember-cli-deploy` pipeline is written generically, which is a strength. Deployment, however, is a specific domain. Capturing tasks in domain objects such as files, revisions and existing deployments, would help in providing a stable public centralized API which can be reliably consumed.
+- readFiles
+- readRevisions
+- (... to be completed)
 
 # Drawbacks
 
-- Many plugins currently rely on the `context` object, new plugins as well as plugins transitioned from the previous data structure in version `0.4`.
-- The flexibility of the `context` object disappears largely, so does easy extensibility and adaptability.
-- The example of the `gzip`, `sentry` and `s3` plugins is not well solved by either of the two solutions proposed.
+- Plugin ordering concerns, e.g. of the `gzip`, `sentry` and `s3` plugins is not well solved by the proposed solution, and remains an open discussion on managing dependencies.
+
+# Alternatives
+
+1. If plugins emit what information they would want to consume (files, a minimatch pattern, revision hash, previous deployments) as subscribers on these topics, plus what they could produce as producers on these topics, an automated plugin ordering could be made, also removing the need for set hooks. Context information would be per-topic, passed into the function, instead of globally available.
 
 # Unresolved questions
 

--- a/rfc/2016-03-context.md
+++ b/rfc/2016-03-context.md
@@ -1,0 +1,40 @@
+# Summary
+
+The `context` object, while flexible, is a poor representation of the domain model of deployment. A topic-based `pub/sub` might prove more robust, as might implementing a strict domain model.
+
+More than proposing a definite solution, this should be seen literally as a request for comments.
+
+# Background
+
+The `ember-cli-deploy` project uses a pipeline to trigger their different stages of deployment. Those stages are, in short, `configure`, `build`, `upload`, `activate`. Plugins installed to the `ember-cli` project have hooks triggered in those stages, where they have a chance to perform their function.
+
+Throughout the pipeline plugins read, write and share state through the so-called `context` object, a hash which can contain raw values and also functions. An example would be the `ember-cli-deploy-build` plugin, which in the `build` step compiles the container `ember-cli` project and writes the resulting array of files to `context.distFiles`. Other plugins then follow to upload those files to s3, Azure or other services.
+
+# Issues
+
+An informal domain model is less suited for a growing ecosystem. Implicit dependencies and decentralized decisions about plugin ordering makes maintaining the ecosystem challanging.
+
+The ecosystem of plugins has grown to a total of 57 by now. They have dependencies on the information and information format put into the `context` object, plus the timing of the hooks:
+- if `context.distFiles` would be renamed to `context.files`, all plugins that consume this information would need to be updated.
+- if `ember-cli-deploy-revision-data`, a plugin to generate a unique fingerprint for a build, were to move their pipeline hook from `didBuild` (running after `build`) to `prepare` (running between `build` and `upload`), any plugins in `didBuild` and `willPrepare`, before having access to this information, now do not.
+
+With the 57 plugins, many combinations of plugins are possible for a single deployment configuration. One might put together `build`, `revision-data`, `gzip`, `s3-index` and `sentry`. The `sentry` plugin edits `index.html` to add in the `revision-data` hash, so bugs in production can be attributed to the right version. Imagine `index.html` were also gzipped. Should `gzip` take place before or after adding the hash to `index.html`?
+
+The `gzip` plugin enables other plugins to be quite agnostic about whether it ran its operation: all it does is replace the list of distFiles with a list of gzipped files. However, in some cases, the not yet compressed files are also required. Should the `gzip` plugin present this information side by side, or should the output of `build` and `gzip` be distinct, so that plugins could consume what suits them?
+
+The plugin author of each plugin at the moment has to make sure that their plugin assumes the right position in ordering in respect to the other plugins. It is not hard to imagine a scenario where constraints in plugin ordering arise which cannot be satisfied (A depends on B, B depends on C, C depends on A) or a scenario where two use cases exist that require different plugin ordering.
+
+# Proposals
+
+1. If plugins emit what information they would want to consume (files, a minimatch pattern, revision hash, previous deployments) as subscribers on these topics, plus what they could produce as producers on these topics, an automated plugin ordering could be made, also removing the need for set hooks. Context information would be per-topic, passed into the function, instead of globally available.
+2. The `ember-cli-deploy` pipeline is written generically, which is a strength. Deployment, however, is a specific domain. Capturing tasks in domain objects such as files, revisions and existing deployments, would help in providing a stable public centralized API which can be reliably consumed.
+
+# Drawbacks
+
+- Many plugins currently rely on the `context` object, new plugins as well as plugins transitioned from the previous data structure in version `0.4`.
+- The flexibility of the `context` object disappears largely, so does easy extensibility and adaptability.
+- The example of the `gzip`, `sentry` and `s3` plugins is not well solved by either of the two solutions proposed.
+
+# Unresolved questions
+
+- FastBoot and potential needs for provisioning over just deployment have not been considered.


### PR DESCRIPTION
Do not merge until finalized. [Rendered content](https://github.com/ember-cli/ember-cli-deploy/blob/rfc/context/rfc/2016-03-context.md).

Open exploration:
- [ ] Scan the 57 plugins and cluster by functionality, extracting what information is consumed & produced
- [ ] Scan which plugins use functions in the `context` object.

Coding efforts:
- [ ] Immutability of the `context` object
- [ ] `readConfig` semantics, preferably `readContext`
