### PR TITLE
Bump lodash version to remove warning

### DIFF
--- a/lib/models/pipeline.js
+++ b/lib/models/pipeline.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Promise = require('ember-cli/lib/ext/promise');
-var _       = require('lodash-node');
+var _       = require('lodash');
 
 var chalk = require('chalk');
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ember-cli-babel": "^5.1.3",
     "dotenv": "^1.1.0",
     "glob": "4.4.2",
-    "lodash-node": "^2.4.1",
+    "lodash": "^4.0.0",
     "mkdirp": "^0.5.0",
     "ncp": "^2.0.0",
     "rimraf": "^2.2.8",


### PR DESCRIPTION
The first commit appeared to pass the tests when it still had a reference to 'lodash-node' in `lib/models/pipeline.js`, which makes me a bit skeptical.