### PR TITLE
Update ember-cli links to ember-cli-deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Huge thanks to the fine work of the ember-cli-deploy core team, particularly @gh
 
 ### Plugin Authors
 
-The `fetchRevisions` hook is now be called during the "deploy" and "activate" pipelines. It was previously only called during the "list" pipeline. In addition, a new `fetchInitialRevisions` hook will be called during the "deploy" and "activate" pipelines. See the [0.6.x Pipeline Hooks docs](http://ember-cli.com/ember-cli-deploy/docs/v0.6.x/pipeline-hooks/) for details. If you maintain a plugin that uploads new revisions, you will want to update your plugin to implement the new hook. Here is an example of [updating ember-cli-deploy-redis](https://github.com/ember-cli-deploy/ember-cli-deploy-redis/pull/50).
+The `fetchRevisions` hook is now be called during the "deploy" and "activate" pipelines. It was previously only called during the "list" pipeline. In addition, a new `fetchInitialRevisions` hook will be called during the "deploy" and "activate" pipelines. See the [0.6.x Pipeline Hooks docs](http://ember-cli-deploy.github.io/ember-cli-deploy/docs/v0.6.x/pipeline-hooks/) for details. If you maintain a plugin that uploads new revisions, you will want to update your plugin to implement the new hook. Here is an example of [updating ember-cli-deploy-redis](https://github.com/ember-cli-deploy/ember-cli-deploy-redis/pull/50).
 
 You should also update your ember-cli-deploy-plugin dependency to 0.2.2, to ensure your plugin's logging plays nicely with the nifty new progress bar in this ember-cli-deploy release.
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ ember install ember-cli-deploy
 ```
 ## Quick start
 
-After installation, choose [plugins](http://ember-cli.github.io/ember-cli-deploy/docs/v0.5.x/plugins/) matching your deployment environment, [configure](http://ember-cli.github.io/ember-cli-deploy/docs/v0.5.x/configuration-overview/) your deployment script appropriately and you're ready to [start deploying](http://ember-cli.github.io/ember-cli-deploy/docs/v0.5.x/usage-overview/).
+After installation, choose [plugins](http://ember-cli-deploy.github.io/ember-cli-deploy/docs/v0.5.x/plugins/) matching your deployment environment, [configure](http://ember-cli-deploy.github.io/ember-cli-deploy/docs/v0.5.x/configuration-overview/) your deployment script appropriately and you're ready to [start deploying](http://ember-cli-deploy.github.io/ember-cli-deploy/docs/v0.5.x/usage-overview/).
 
 ## In-depth documentation
 
-[Visit the Docs site](http://ember-cli.github.io/ember-cli-deploy/)
+[Visit the Docs site](http://ember-cli-deploy.github.io/ember-cli-deploy/)
 
 ## Contributing
 

--- a/blueprints/ember-cli-deploy/index.js
+++ b/blueprints/ember-cli-deploy/index.js
@@ -9,6 +9,6 @@ module.exports = {
     // to us
   },
   afterInstall: function(options) {
-    this.ui.write(green('ember-cli-deploy needs plugins to actually do the deployment work.\nSee http://ember-cli.github.io/ember-cli-deploy/docs/v0.5.x/quick-start/\nto learn how to install plugins and see what plugins are available.\n'));
+    this.ui.write(green('ember-cli-deploy needs plugins to actually do the deployment work.\nSee http://ember-cli-deploy.github.io/ember-cli-deploy/docs/v0.5.x/quick-start/\nto learn how to install plugins and see what plugins are available.\n'));
   }
 };

--- a/lib/tasks/pipeline.js
+++ b/lib/tasks/pipeline.js
@@ -46,7 +46,7 @@ module.exports = Task.extend({
       self.ui.writeError("\nWARNING: No plugins installed.\n");
       self.ui.writeError("ember-cli-deploy works by registering plugins in its pipeline.");
       self.ui.writeError("In order to execute a deployment you must install at least one ember-cli-deploy compatible plugin.\n");
-      self.ui.writeError("Visit http://ember-cli.github.io/ember-cli-deploy/docs/v0.5.x/plugins/ for a list of supported plugins.\n");
+      self.ui.writeError("Visit http://ember-cli-deploy.github.io/ember-cli-deploy/docs/v0.5.x/plugins/ for a list of supported plugins.\n");
     }
 
     pluginNames.forEach(function(pluginName) {


### PR DESCRIPTION
Updates all instances of `http://ember-cli.github.io` and `http://ember-cli.com` to `http://ember-cli-deploy.github.io`