### PR TITLE
Fix plugin context merging in the pipeline model

### DIFF
--- a/lib/models/pipeline.js
+++ b/lib/models/pipeline.js
@@ -172,7 +172,7 @@ Pipeline.prototype._notifyPipelinePluginHookExecution = function(ui, fnObject, h
 };
 
 Pipeline.prototype._mergePluginHookResultIntoContext = function(context,result) {
-  return _.merge(context, result, function(a, b) {
+  return _.mergeWith(context, result, function(a, b) {
     if (_.isArray(a)) {
       return a.concat(b);
     }

--- a/node-tests/unit/models/pipeline-test.js
+++ b/node-tests/unit/models/pipeline-test.js
@@ -173,6 +173,24 @@ describe ('Pipeline', function() {
           expect(finalContext.age).to.equal(47);
         });
     });
+
+    it('merges the return value of each hook with the context using concatenation', function() {
+      var subject = new Pipeline(['hook1'], {ui: {write: function() {}}});
+      var finalContext = null;
+
+      subject.register('hook1', function() {
+        return { paths: ['/tmp/path', '/var/path'] };
+      });
+
+      subject.register('hook1', function(context) {
+        finalContext = context;
+      });
+
+      return expect(subject.execute({paths: ['/opt/path']})).to.be.fulfilled
+        .then(function() {
+          expect(finalContext.paths).to.deep.equal(['/opt/path', '/tmp/path', '/var/path']);
+        });
+    });
   });
 
   describe('#hookNames', function() {


### PR DESCRIPTION
Since upgrading to lodash `^4.0.0` in v0.6.2 pipeline context merging
has been broken. When your hook result has an object that exists in
the context already (e.g. `distFiles`) then the results of your hook are
no longer concatenated but instead overwrite the existing values.

For example, if you have `context.distFiles` set to `['file1', file2']`
and your hook returns `{distFiles: ['file3']}` then the resulting distFiles
array is now `['file3', 'file2']`, not `['file1', 'file2', 'file3']` as it
was before.

This is because the `_.merge` function used to merge the contexts was
changed in lodash 4 and is now a simple merger that takes an object and
one or more sources to merge into that object; it no longer takes a custom
merge function. To use a merge function you need to change to use
`_.mergeWith`.

I've made this change and added a test to ensure regression does not
happen in future.