### PR TITLE
Validate configured plugins before continue with pipeline

### DIFF
--- a/lib/tasks/pipeline.js
+++ b/lib/tasks/pipeline.js
@@ -112,7 +112,7 @@ module.exports = Task.extend({
     });
 
     if (Object.keys(unavailablePlugins).length !== 0) {
-      this.ui.writeError(unavailablePlugins);
+      this.ui.writeError(Object.keys(unavailablePlugins));
       var error = new SilentError('plugins configuration references plugins which are not available.');
       error.unavailablePlugins = unavailablePlugins;
       throw error;


### PR DESCRIPTION
Hi guys, I just added a method to validate the configured plugins before continuing with the pipeline, it basically checks if the installed ones contains the configured ones.

I think this could be really useful for the user to get a nicer feedback instead of just failing after that and showing an unrelated error: **Cannot convert object to primitive value**

It took me some time to me to realize that I was trying to use a plugin that i didn't had installed...

Not sure if we should also throw an error and finish the process somehow... I'm not that familiar about how do you handle this kind of errors here :)

Thanks!

