### PR TITLE
add support for requiredHooks in pipelines

### DIFF
--- a/lib/commands/activate.js
+++ b/lib/commands/activate.js
@@ -51,6 +51,9 @@ module.exports = {
           'fetchRevisions',
           'didActivate',
           'teardown'
+        ],
+        requiredHooks: [
+          'activate'
         ]
       });
 

--- a/lib/commands/list.js
+++ b/lib/commands/list.js
@@ -49,6 +49,10 @@ module.exports = {
           'fetchRevisions',
           'displayRevisions',
           'teardown'
+        ],
+        requiredHooks: [
+          'fetchRevisions',
+          'displayRevisions'
         ]
       });
 

--- a/lib/models/pipeline.js
+++ b/lib/models/pipeline.js
@@ -52,6 +52,10 @@ Pipeline.prototype.register = function(hookName, fn) {
   }
 };
 
+Pipeline.prototype.hasHandlersForHook = function(hook) {
+  return this._pipelineHooks[hook].length !== 0;
+};
+
 Pipeline.prototype.execute = function(context) {
   context = context || { };
 

--- a/lib/tasks/pipeline.js
+++ b/lib/tasks/pipeline.js
@@ -52,6 +52,17 @@ module.exports = Task.extend({
     pluginNames.forEach(function(pluginName) {
       self._registerPipelineHooks(plugins[pluginName], pluginName);
     });
+
+    self._validatePresenceOfRequiredHooks();
+  },
+
+  _validatePresenceOfRequiredHooks: function() {
+    (this.requiredHooks || []).forEach(function(hook) {
+      if (!this._pipeline.hasHandlersForHook(hook)) {
+        var error = new SilentError(hook + ' not implemented by any registered plugin');
+        throw error;
+      }
+    }.bind(this));
   },
 
   _discoverInstalledPlugins: function(){

--- a/node-tests/unit/tasks/pipeline-test.js
+++ b/node-tests/unit/tasks/pipeline-test.js
@@ -217,6 +217,83 @@ describe('PipelineTask', function() {
         expect(registeredHooks.upload[0].name).to.eq('foo-plugin');
         expect(registeredHooks.upload[0].fn).to.be.a('function');
       });
+
+      describe('requiredHooks', function() {
+        it('validates that required hooks are implemented', function () {
+          var project = {
+            name: function() {return 'test-project';},
+            root: process.cwd(),
+            addons: [
+              {
+                name: 'ember-cli-deploy-foo-plugin',
+                pkg: {
+                  keywords: [
+                    'ember-cli-deploy-plugin'
+                  ]
+                },
+                createDeployPlugin: function() {
+                  return {
+                    name: 'foo-plugin',
+                    willDeploy: function() {},
+                    upload: function() {}
+                  };
+                }
+              }
+            ]
+          };
+
+          var task = new PipelineTask({
+            project: project,
+            ui: mockUi,
+            deployTarget: 'development',
+            config: { plugins: ['foo-plugin'] },
+            hooks: ['willDeploy', 'upload'],
+            requiredHooks: ['willDeploy']
+          });
+          var fn = function() {
+            task.setup();
+          };
+          expect(fn).to.not.throw(/not implemented by any registered plugin/);
+        });
+
+        it('throws if required hooks are not implemented', function () {
+          var project = {
+            name: function() {return 'test-project';},
+            root: process.cwd(),
+            addons: [
+              {
+                name: 'ember-cli-deploy-foo-plugin',
+                pkg: {
+                  keywords: [
+                    'ember-cli-deploy-plugin'
+                  ]
+                },
+                createDeployPlugin: function() {
+                  return {
+                    name: 'foo-plugin',
+                    willDeploy: function() {},
+                    upload: function() {}
+                  };
+                }
+              }
+            ]
+          };
+
+          var task = new PipelineTask({
+            project: project,
+            ui: mockUi,
+            deployTarget: 'development',
+            config: { plugins: ['foo-plugin'] },
+            hooks: ['willDeploy', 'upload', 'fetchRevisions'],
+            requiredHooks: ['fetchRevisions']
+          });
+          var fn = function() {
+            task.setup();
+          };
+          expect(fn).to.throw('fetchRevisions not implemented by any registered plugin');
+        });
+      });
+
       it('registers dependent plugin addons of a plugin pack addon designated by the ember-cli-deploy-plugin-pack keyword', function() {
         var project = {
           name: function() {return 'test-project';},


### PR DESCRIPTION
## What changed and Why

A lot of users seem to hit cases where a command is not working properly because of a missing pluging in their setup.

The most common is running `ember deploy:list TARGET` without having `ember-cli-deploy-display-revisions` installed or an equivalent plugin

This PR adds support for a `requiredHooks` configuration parameter for the PipelineTask that we can use to throw an error when none of the available plugins implements the required hook.


## Open Questions:

What other hook should we require to be implemented for `list` and the other commands (if any)?

Shall we change the format of the `hooks` property to be something like
```
hooks: [
  { name: 'fetchRevisions', required: true}
  { name: 'willUpload', required: false }
]
``` 
or any other format?

## Related Issues
https://github.com/ember-cli-deploy/ember-cli-deploy/issues/386


/cc @achambers @lukemelia 
