### PR TITLE
Fix CoreObject init/super deprecation

### DIFF
--- a/lib/tasks/deploy.js
+++ b/lib/tasks/deploy.js
@@ -3,6 +3,10 @@ var PipelineTask = require('../tasks/pipeline');
 
 module.exports = Task.extend({
   init: function() {
+    if (this._super.init) {
+      this._super.init.apply(this, arguments);
+    }
+
     this.commandOptions = this.commandOptions || {};
     this.shouldActivate = this.shouldActivate || this._shouldActivate(this.commandOptions);
   },

--- a/lib/tasks/pipeline.js
+++ b/lib/tasks/pipeline.js
@@ -4,6 +4,10 @@ var Pipeline = require('../models/pipeline');
 
 module.exports = Task.extend({
   init: function() {
+    if (this._super.init) {
+      this._super.init.apply(this, arguments);
+    }
+
     if (!this.project) {
       throw new SilentError('No project passed to pipeline task');
     }

--- a/lib/tasks/read-config.js
+++ b/lib/tasks/read-config.js
@@ -8,6 +8,10 @@ var dotenv      = require('dotenv');
 
 module.exports = Task.extend({
   init: function() {
+    if (this._super.init) {
+      this._super.init.apply(this, arguments);
+    }
+
     if (!this.project) {
       throw new SilentError('No project passed to read-config task');
     }


### PR DESCRIPTION
## What Changed & Why
In the three core tasks, check for existence of `this._super.init` and call it if present. This fixes a CoreObject deprecation.

## Related issues
Fixes #409
