### PR TITLE
Remove extraneous `something` config value

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = function(/* environment */) {
-  return { something: 'test' };
+  return {};
 };


### PR DESCRIPTION
## What Changed & Why
Removed the `something: 'test'` property in `config/environment.js`. Not sure if it was some debugging code that was mistaken left in, or if it serves some legitimate purpose.

It was introduced in 2fafafcd3129041bead33774991aa03f358fb7ee, but a search of the codebase reveals no other use of the string `something` in the code.

## Related issues
None that I could find.

## PR Checklist
- [ ] ~~Add tests~~ N/A
- [ ] ~~Add documentation~~ N/A
- [ ] ~~Prefix documentation-only commits with [DOC]~~ N/A

## People
@achambers (the original author of that commit)