### PR TITLE
Make plugin alias example consistent

### DIFF
--- a/docs/v1.0.0-beta.1/including-a-plugin-twice.md
+++ b/docs/v1.0.0-beta.1/including-a-plugin-twice.md
@@ -10,7 +10,7 @@ We can do this by using the `pipeline.alias` config option, like so:
   var ENV = {
     pipeline: {
       alias: {
-        s3: { as: ['s3', 's3-backup'] },
+        s3: { as: ['s3-eu', 's3-us'] },
       },
     },
   };
@@ -26,11 +26,11 @@ This configuration will then allow you to set different configuration options fo
       },
     },
 
-    s3: {
+    's3-eu': {
       bucket: 'bucket-1',
     },
 
-    's3-backup': {
+    's3-us': {
       bucket: 'bucket-2',
     },
   };
@@ -42,7 +42,7 @@ You can pass either a string or an array of strings in as the alias value like s
   var ENV = {
     pipeline: {
       alias: {
-        s3: { as: ['s3', 's3-backup'] },
+        s3: { as: ['s3-eu', 's3-us'] },
         redis: { as: 'redis-local' },
       },
     },


### PR DESCRIPTION
## What Changed & Why
Just updating the plugin alias example for consistency.

Not sure if you want a consistent example through this entire page. As in carrying either `['s3', 's3-backup']` or `['s3-eu', 's3-us']` throughout all examples on this page.


## PR Checklist
- [ ] Add tests
- [ ] Add documentation
- [x] Prefix documentation-only commits with [DOC]
