### PR TITLE
Use own task model

### DIFF
--- a/lib/models/task.js
+++ b/lib/models/task.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var CoreObject = require('core-object');
+
+var Task = CoreObject.extend({
+  run: function(/*options*/) {
+    throw new Error('Task needs to have run() defined.');
+  }
+});
+
+module.exports = Task;

--- a/lib/tasks/deploy.js
+++ b/lib/tasks/deploy.js
@@ -1,4 +1,4 @@
-var Task        = require('ember-cli/lib/models/task');
+var Task         = require('../models/task');
 var PipelineTask = require('../tasks/pipeline');
 
 module.exports = Task.extend({

--- a/lib/tasks/pipeline.js
+++ b/lib/tasks/pipeline.js
@@ -1,4 +1,4 @@
-var Task           = require('ember-cli/lib/models/task');
+var Task           = require('../models/task');
 var SilentError    = require('silent-error');
 var Pipeline       = require('../models/pipeline');
 var PluginRegistry = require('../models/plugin-registry');

--- a/lib/tasks/read-config.js
+++ b/lib/tasks/read-config.js
@@ -1,4 +1,4 @@
-var Task        = require('ember-cli/lib/models/task');
+var Task        = require('../models/task');
 var RSVP        = require('rsvp');
 var SilentError = require('silent-error');
 


### PR DESCRIPTION
## What Changed & Why
Moved away from using the shared `Task` model from `ember-cli`.

## Related issues
https://github.com/ember-cli-deploy/ember-cli-deploy/issues/358

