### PR TITLE
Pass on negative exit codes on failure

### DIFF
--- a/lib/models/pipeline.js
+++ b/lib/models/pipeline.js
@@ -126,7 +126,7 @@ Pipeline.prototype._abortPipelineExecution = function(ui/*, error */) {
     ui.write(this.logInfo('|\n'));
   }
   ui.write(this.logError('Pipeline aborted\n'));
-  return RSVP.reject();
+  return -1;
 };
 
 Pipeline.prototype._notifyPipelineCompletion = function(ui) {
@@ -134,6 +134,7 @@ Pipeline.prototype._notifyPipelineCompletion = function(ui) {
     ui.write(this.logInfo('|\n'));
     ui.write(this.logInfo('Pipeline complete\n'));
   }
+  return 0;
 };
 
 Pipeline.prototype._notifyPipelineHookExecution = function(ui, hookName, context) {

--- a/node-tests/unit/models/pipeline-test.js
+++ b/node-tests/unit/models/pipeline-test.js
@@ -73,7 +73,8 @@ describe ('Pipeline', function() {
         hooksRun.push('2');
       });
       return expect(subject.execute()).to.be.fulfilled
-        .then(function() {
+        .then(function(returnCode) {
+          expect(returnCode).to.eq(0);
           expect(hooksRun.length).to.eq(2);
           expect(hooksRun[0]).to.eq('1');
           expect(hooksRun[1]).to.eq('2');
@@ -100,8 +101,9 @@ describe ('Pipeline', function() {
         hooksRun.push('didFail');
       });
 
-      return expect(subject.execute()).to.be.rejected
-        .then(function() {
+      return expect(subject.execute()).to.be.fulfilled
+        .then(function(returnCode) {
+          expect(returnCode).to.eq(-1);
           expect(hooksRun.length).to.eq(2);
           expect(hooksRun[0]).to.eq('hook1');
           expect(hooksRun[1]).to.eq('didFail');


### PR DESCRIPTION
## What Changed & Why
Return non-zero exit code when pipeline fails.

## Related issues
https://github.com/ember-cli-deploy/ember-cli-deploy/issues/417

## People
@v-shan

Demo:
![exit-code](https://cloud.githubusercontent.com/assets/665795/20958684/129c790e-bc57-11e6-95ab-96d6f4bcc24f.png)