### PR TITLE
Use dag-map instead of ember-cli internal dag

### DIFF
--- a/lib/models/plugin-registry.js
+++ b/lib/models/plugin-registry.js
@@ -1,5 +1,5 @@
 var CoreObject  = require('core-object');
-var DAG         = require('ember-cli/lib/utilities/DAG');
+var DAG         = require('dag-map').default;
 var SilentError = require('silent-error');
 var chalk       = require('chalk');
 var _           = require('lodash');
@@ -246,11 +246,11 @@ module.exports = CoreObject.extend({
       pluginInstances.forEach(function(instance) {
         var before = (runOrderMap[instance.name] && self._castArray(runOrderMap[instance.name].before)) || [];
         var after = (runOrderMap[instance.name] && self._castArray(runOrderMap[instance.name].after)) || [];
-        graph.addEdges(instance.name, instance, before, after);
+        graph.add(instance.name, instance, before, after);
       });
 
-      graph.topsort(function (vertex) {
-        sortedInstances.push(vertex.value);
+      graph.topsort(function (key, value) {
+        sortedInstances.push(value);
       });
     } catch(err) {
       if (/cycle detected/.test(err)) {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "core-object": "^2.0.0",
+    "dag-map": "^2.0.1",
     "dotenv": "^1.2.0",
     "ember-cli-deploy-progress": "^1.3.0",
     "lodash": "^4.0.0",


### PR DESCRIPTION
## What Changed & Why
Use dag-map directly instead of relying on ember-cli, so we can drop the latter as a dependency.

## Related issues
https://github.com/ember-cli-deploy/ember-cli-deploy/issues/358