### PR TITLE
Update outdated link in afterInstall message

### DIFF
--- a/blueprints/ember-cli-deploy/index.js
+++ b/blueprints/ember-cli-deploy/index.js
@@ -9,6 +9,6 @@ module.exports = {
     // to us
   },
   afterInstall: function(options) {
-    this.ui.write(green('ember-cli-deploy needs plugins to actually do the deployment work.\nSee http://ember-cli-deploy.com quickstart section\nto learn how to install plugins and see what plugins are available.\n'));
+    this.ui.write(green('ember-cli-deploy needs plugins to actually do the deployment work.\nSee http://ember-cli-deploy.com/docs/v1.0.0-beta/quickstart/\nto learn how to install plugins and see what plugins are available.\n'));
   }
 };

--- a/blueprints/ember-cli-deploy/index.js
+++ b/blueprints/ember-cli-deploy/index.js
@@ -9,6 +9,6 @@ module.exports = {
     // to us
   },
   afterInstall: function(options) {
-    this.ui.write(green('ember-cli-deploy needs plugins to actually do the deployment work.\nSee http://ember-cli-deploy.github.io/ember-cli-deploy/docs/v0.5.x/quick-start/\nto learn how to install plugins and see what plugins are available.\n'));
+    this.ui.write(green('ember-cli-deploy needs plugins to actually do the deployment work.\nSee http://ember-cli-deploy.com quickstart section\nto learn how to install plugins and see what plugins are available.\n'));
   }
 };


### PR DESCRIPTION
* Use ember-cli-deploy.com instead of ember-cli-deploy.github.io

* Remove version from the link
The downside of this is that getting to the quick section is more than one copy paste away
The good part is that this blueprint will not demand changes after changing versions

