### PR TITLE
fix typo in plugin name

### DIFF
--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -53,7 +53,7 @@ The following plugin packs are maintained by the Ember CLI deploy core team:
 The following plugin packs are developed by community members:
 
 - [ember-cli-deploy-aws-pack](https://github.com/kpfefferle/ember-cli-deploy-aws-pack)
-- [ember=cli-deploy-s3-pack](https://github.com/gaurav0/ember-cli-deploy-s3-pack)
+- [ember-cli-deploy-s3-pack](https://github.com/gaurav0/ember-cli-deploy-s3-pack)
 - [ember-cli-deploy-azure](https://github.com/duizendnegen/ember-cli-deploy-azure)
 - [ember-pagefront](https://github.com/pagefront/ember-pagefront)
 - [ember-cli-deploy-front-end-builds-pack](https://github.com/tedconf/ember-cli-deploy-front-end-builds-pack)


### PR DESCRIPTION
## What Changed & Why

Fixes a typo in a plugin name in docs.

## Related issues
N/A

## PR Checklist
- [ ] ~Add tests~
- [x] Add documentation
- [ ] ~Prefix documentation-only commits with [DOC]~

## People
N/A