### PR TITLE
Update target for "improve this page" links in docs.

### DIFF
--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -41,7 +41,7 @@ layout: default
   <div class="Center-panel">
     <div class="Docs-page">
       <div class='Docs-page__header'>
-        <a class='Docs-page__improve-link' href="https://github.com/ember-cli-deploy/ember-cli-deploy/edit/gh-pages/{{page.path}}">
+        <a class='Docs-page__improve-link' href="https://github.com/ember-cli-deploy/ember-cli-deploy/edit/master/docs/{{page.path}}">
           <img src="{{ site.baseurl}}/public/images/edit.png" alt="">
           Improve this page
         </a>


### PR DESCRIPTION
In https://github.com/ember-cli-deploy/ember-cli-deploy/pull/446 the actual website/docs info was moved from gh-pages branch to master branch, but this link wasn't noticed at the time.

---

Prior to this change the improve this page link pointed at the older gh-pages branch:

https://github.com/ember-cli-deploy/ember-cli-deploy/edit/gh-pages/docs/v1.0.x/configuration.md

After this change, it points at:

https://github.com/ember-cli-deploy/ember-cli-deploy/edit/master/docs/docs/v1.0.x/configuration.md