### PR TITLE
Fix test commands to include all tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "node node_modules/mocha/bin/mocha node-tests/**/*-test.js",
-    "autotest": "node node_modules/mocha/bin/mocha --watch --reporter spec node-tests/**/*-test.js"
+    "test": "node node_modules/mocha/bin/mocha node-tests/unit/*-test.js node-tests/unit/*/*-test.js",
+    "autotest": "node node_modules/mocha/bin/mocha --watch --reporter spec node-tests/unit/*-test.js node-tests/unit/*/*-test.js"
   },
   "repository": "https://github.com/ember-cli-deploy/ember-cli-deploy",
   "engines": {
@@ -22,7 +22,7 @@
     "ember-cli": "^2.10.0",
     "ember-cli-release": "0.2.9",
     "github": "0.2.3",
-    "mocha": "^2.0.1",
+    "mocha": "^3.2.0",
     "mocha-jshint": "^2.2.6"
   },
   "keywords": [


### PR DESCRIPTION
## What Changed & Why
I've noticed that `npm run test` only runs tests from `index-test.js`.

Here's the latest build on `master` as of Feb 20:
https://travis-ci.org/ember-cli-deploy/ember-cli-deploy/builds/201523239

For some reason, the glob `**` works as a single asterisk `*`, meaning exactly one level of depth. I've updated Mocha, but it didn't resolve the problem. `--recursive` didn't help either.

So I updated the test command to include paths with two distinct levels of depth.

## Bonus
Bumped `mocha` version.

## People
@lukemelia @LevelbossMike