### PR TITLE
Add ember-cli-deploy-git-artefacts to the community plugin list

### DIFF
--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -31,6 +31,7 @@ The following plugins have been developed by community members:
   - [ember-cli-deploy-cloudfront](https://github.com/kpfefferle/ember-cli-deploy-cloudfront) - create a CloudFront invalidation
   - [ember-cli-deploy-couchdb](https://github.com/martinic/ember-cli-deploy-couchdb) - upload to a CouchDB cluster
   - [ember-cli-deploy-cp](https://github.com/dschmidt/ember-cli-deploy-cp) - deploy file(s) on your filesystem
+  - [ember-cli-deploy-git-artefacts](https://github.com/avakarev/ember-cli-deploy-git-artefacts) - generates git artefacts into files
   - [ember-cli-deploy-git-tag](https://github.com/minutebase/ember-cli-deploy-git-tag) - tag deploys in git
   - [ember-cli-deploy-hipchat](https://github.com/blimmer/ember-cli-deploy-hipchat) - send a message to HipChat
   - [ember-cli-deploy-mysql](https://github.com/mwpastore/ember-cli-deploy-mysql) - deploy index.html to MySQL/MariaDB


### PR DESCRIPTION
## What Changed & Why
Add ember-cli-deploy-git-artefacts to the community plugin list.

This plugin generates git artefacts into files like
```bash
○ $:> cat dist/branch.txt
release/v1.2
○ $:> cat dist/tag.txt
v1.2.0
○ $:> cat dist/revision.txt
2a8bc4a42a221e038dfec684a98aa2cd521c4ee9
```
## Related issues
Link to related issues in this or other repositories (if any)

## PR Checklist
- [x] Add tests
- [x] Add documentation
- [x] Prefix documentation-only commits with [DOC]

## People
Mention people who would be interested in the changeset (if any)