### PR TITLE
Fix upgrade guide to have correct syntax for aliasing plugins

### DIFF
--- a/docs/docs/v1.0.x/upgrading.md
+++ b/docs/docs/v1.0.x/upgrading.md
@@ -24,7 +24,7 @@ They are now 3 separate configurations, and you can pick only the ones you need:
 ```js
 ENV.pipeline = {
   alias: {
-    s3: ['s3-foo']
+    s3: { as: ['s3-foo'] }
   },
   disabled: {
     allExcept: ['build', 'redis', 's3-foo']


### PR DESCRIPTION
## What Changed & Why
The guide for upgrading from 0.6 to 1.0 contained incorrect syntax for aliasing plugins. The correct syntax is found here: http://ember-cli-deploy.com/docs/v1.0.x/including-a-plugin-twice/