### PR TITLE
[DOC] Replace ember-cli-deploy-mysql with -sql

### DIFF
--- a/plugins/index.md
+++ b/plugins/index.md
@@ -33,7 +33,7 @@ The following plugins have been developed by community members:
   - [ember-cli-deploy-cp](https://github.com/dschmidt/ember-cli-deploy-cp) - deploy file(s) on your filesystem
   - [ember-cli-deploy-git-tag](https://github.com/minutebase/ember-cli-deploy-git-tag) - tag deploys in git
   - [ember-cli-deploy-hipchat](https://github.com/blimmer/ember-cli-deploy-hipchat) - send a message to HipChat
-  - [ember-cli-deploy-mysql](https://github.com/mwpastore/ember-cli-deploy-mysql) - deploy index.html to MySQL/MariaDB
+  - [ember-cli-deploy-sql](https://github.com/mwpastore/ember-cli-deploy-sql) - deploy index.html to a database table
   - [ember-cli-deploy-scp](https://github.com/michaljach/ember-cli-deploy-scp) - deploy app using SCP via SSH
   - [ember-cli-deploy-webhooks](https://github.com/simplabs/ember-cli-deploy-webhooks) - call webhooks during deployments
   - [ember-cli-deploy-notify-firebase](https://github.com/minutebase/ember-cli-deploy-notify-firebase) - update a path in Firebase on activation


### PR DESCRIPTION
## What Changed & Why

* Remove ember-cli-deploy-mysql (deprecated)
* Add ember-cli-deploy-sql

## Related issues

N/A

## PR Checklist
- [ ] ~~Add tests~~ N/A
- [ ] ~~Add documentation~~ N/A
- [X] Prefix documentation-only commits with [DOC]

## People

Just me, myself, and I!