### PR TITLE
Allow more flexible plugin naming

### DIFF
--- a/lib/models/plugin-registry.js
+++ b/lib/models/plugin-registry.js
@@ -273,8 +273,11 @@ module.exports = CoreObject.extend({
   },
 
   _pluginName: function(addon) {
-    var pluginNameRegex = /^(ember\-cli\-deploy\-)(.*)$/;
-    return addon.name.match(pluginNameRegex)[2];
+    if(addon.name.indexOf('ember-cli-deploy') > -1) {
+      var pluginNameRegex = /^(ember\-cli\-deploy\-)(.*)$/;
+      return addon.name.match(pluginNameRegex)[2];
+    }
+    return addon.name;
   },
 
   _addonHasKeyword: function(addon, keyword) {

--- a/node-tests/unit/models/plugin-registry-test.js
+++ b/node-tests/unit/models/plugin-registry-test.js
@@ -90,6 +90,26 @@ describe('Plugin Registry', function() {
     expect(logOutput[3]).to.eq('Visit http://ember-cli-deploy.com/plugins/ for a list of supported plugins.');
   });
 
+  it('accepts plugins with names not starting with ember-cli-deploy and renames those starting with', function() {
+    var validPlugin = makePlugin('foo');
+    var otherNamedPlugin = makePlugin('bar');
+    otherNamedPlugin.name = 'my-other-bar';
+
+    var project = {
+      name: function() {return 'test-project';},
+      root: process.cwd(),
+      addons: [validPlugin, otherNamedPlugin],
+    };
+
+    var registry = new PluginRegistry(project, mockUi, {});
+
+    var plugins = registry.pluginInstances();
+
+    expect(plugins.length).to.equal(2);
+    expect(plugins[0].name).to.equal('foo');
+    expect(plugins[1].name).to.equal('my-other-bar');
+  });
+
   it('returns plugins for addons that have the correct keyword and implement the plugin function', function() {
     var validPlugin                = makePlugin('foo');
     var addonMissingKeyword        = makeAddon('bar');


### PR DESCRIPTION
## What Changed & Why
Using `deployjs`, addons shouldn't need to start with `ember-cli-deploy` necessarily.

## PR Checklist
- [x] Add tests
- [x] Fix tests