### PR TITLE
Only emit the plugins notice after install if none are present

### DIFF
--- a/blueprints/ember-cli-deploy/index.js
+++ b/blueprints/ember-cli-deploy/index.js
@@ -9,6 +9,14 @@ module.exports = {
     // to us
   },
   afterInstall: function() {
-    this.ui.write(green('ember-cli-deploy needs plugins to actually do the deployment work.\nSee http://ember-cli-deploy.com/docs/v1.0.x/quickstart/\nto learn how to install plugins and see what plugins are available.\n'));
+    var hasPlugins = this.project.addons.some(function(addon) {
+      var isPlugin = addon.pkg.keywords.indexOf('ember-cli-deploy-plugin') !== -1;
+      var isPluginPack = addon.pkg.keywords.indexOf('ember-cli-deploy-plugin-pack') !== -1;
+      return isPlugin || isPluginPack;
+    });
+
+    if (!hasPlugins) {
+      this.ui.write(green('ember-cli-deploy needs plugins to actually do the deployment work.\nSee http://ember-cli-deploy.com/docs/v1.0.x/quickstart/\nto learn how to install plugins and see what plugins are available.\n'));
+    }
   }
 };

--- a/node-tests/unit/blueprint-test.js
+++ b/node-tests/unit/blueprint-test.js
@@ -1,0 +1,69 @@
+var assert = require('../helpers/assert');
+
+describe ('Installation Blueprint', function() {
+  var subject;
+  beforeEach(function() {
+    subject = require('../../blueprints/ember-cli-deploy/index.js');
+  });
+  describe('afterInstall', function() {
+    it('emits a message if no deploy plugins are installed', function() {
+      var called = false;
+      var context = {
+        project: {
+          addons: []
+        },
+        ui: {
+          write: function(message) {
+            assert(/ember-cli-deploy needs plugins to actually do the deployment work/.test(message));
+            called = true;
+          }
+        }
+      };
+
+      subject.afterInstall.call(context);
+      assert(called, 'ui.write() was called');
+    });
+
+    it('emits no message if a deploy plugin is found', function() {
+      var called = false;
+      var context = {
+        project: {
+          addons: [{
+            pkg: {
+              keywords: ['ember-cli-deploy-plugin']
+            }
+          }]
+        },
+        ui: {
+          write: function() {
+            called = true;
+          }
+        }
+      };
+
+      subject.afterInstall.call(context);
+      assert(!called, 'ui.write() was not called');
+    });
+
+    it('emits no message if a deploy plugin pack is found', function() {
+      var called = false;
+      var context = {
+        project: {
+          addons: [{
+            pkg: {
+              keywords: ['ember-cli-deploy-plugin-pack']
+            }
+          }]
+        },
+        ui: {
+          write: function() {
+            called = true;
+          }
+        }
+      };
+
+      subject.afterInstall.call(context);
+      assert(!called, 'ui.write() was not called');
+    });
+  });
+});


### PR DESCRIPTION
Hi! I'm in the process of updating our internal app blueprint at work to include some deploy-related stuff, and it now installs ember-cli-deploy and a plugin pack in one go. Given that, I thought it might be nice to avoid emitting the notice about needing plugins if any were already present.

It doesn't look like the blueprint has any test coverage today, so I didn't add anything to capture this change. If you feel it's worth testing, I'm happy to go back and set something up.