### PR TITLE
[DOC] ember-cli-deploy-simply-ssh added to community plugin list

### DIFF
--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -43,6 +43,7 @@ The following plugins have been developed by community members:
   - [ember-cli-deploy-notify-firebase](https://github.com/minutebase/ember-cli-deploy-notify-firebase) - update a path in Firebase on activation
   - [ember-cli-deploy-sentry](https://github.com/dschmidt/ember-cli-deploy-sentry) - upload javascript sourcemaps to sentry
   - [ember-cli-deploy-rollbar](https://github.com/netguru/ember-cli-deploy-rollbar) - include Rollbar snippet and upload javascript sourcemaps to Rollbar
+  - [ember-cli-deploy-simply-ssh](https://github.com/AutoCloud/ember-cli-deploy-simply-ssh) - deploy via SSH with support of `-revision-data`, `-gzip`, `deploy:list` and `deploy:activate`
 
 For a wide view of the plugin ecosystem, check out [a live search of npm packages with the "ember-cli-deploy-plugin" keyword](https://npmsearch.com/?q=keywords:ember-cli-deploy-plugin).
 


### PR DESCRIPTION
## What Changed & Why
`ember-cli-deploy-simply-ssh` added to community plugin list. This plugin supports revisions and gzipped data, as well as revision switching using `deploy:list`/`deploy:activate`.

## PR Checklist
- [ ] Add tests
- [ ] Add documentation
- [X] Prefix documentation-only commits with [DOC]
