### PR TITLE
[DOC] Plugin pack article typo

### DIFF
--- a/docs/docs/v1.0.x/plugin-packs.md
+++ b/docs/docs/v1.0.x/plugin-packs.md
@@ -53,7 +53,7 @@ The following plugin packs are maintained by the ember-cli-deploy core team:
 The following plugin packs are developed by community members:
 
 - [ember-cli-deploy-aws-pack](https://github.com/kpfefferle/ember-cli-deploy-aws-pack)
-- [ember=cli-deploy-s3-pack](https://github.com/gaurav0/ember-cli-deploy-s3-pack)
+- [ember-cli-deploy-s3-pack](https://github.com/gaurav0/ember-cli-deploy-s3-pack)
 - [ember-cli-deploy-azure](https://github.com/duizendnegen/ember-cli-deploy-azure)
 - [ember-pagefront](https://github.com/pagefront/ember-pagefront)
 - [ember-cli-deploy-front-end-builds-pack](https://github.com/tedconf/ember-cli-deploy-front-end-builds-pack)


### PR DESCRIPTION
## What Changed & Why

  - The name of a plugin now uses a dash, not an equals sign

