### PR TITLE
add --active-only option to list command

### DIFF
--- a/lib/commands/list.js
+++ b/lib/commands/list.js
@@ -13,6 +13,7 @@ module.exports = {
     { name: 'deploy-config-file', type: String, description: '(Default: config/deploy.js)' },
     { name: 'verbose', type: Boolean },
     { name: 'amount', type: Number, description: '(Default: 10)' },
+    { name: 'active-only', type: Boolean, description: 'Show only the active revision no matter how old it is' },
     { name: 'log-info-color', type: String, description: '(Default: "blue")'},
     { name: 'log-error-color', type: String, description: '(Default: "red")'}
   ],
@@ -25,6 +26,7 @@ module.exports = {
     this.ui.logInfoColor = chooseOptionValue(commandOptions.logInfoColor, this.settings, 'logInfoColor', 'blue');
     this.ui.logErrorColor = chooseOptionValue(commandOptions.logErrorColor, this.settings, 'logErrorColor', 'red');
     commandOptions.amount = chooseOptionValue(commandOptions.amount, this.settings, 'amount', 10);
+    commandOptions.activeOnly = chooseOptionValue(commandOptions.activeOnly, this.settings, 'activeOnly');
 
     process.env.DEPLOY_TARGET = commandOptions.deployTarget;
 


### PR DESCRIPTION
We need a way to get the active revision, no matter how old it is. I don't think this is possible now, because you would need to know the amount beforehand.