### PR TITLE
[DOC] Remove pagefront from plugin packs

### DIFF
--- a/docs/docs/v1.0.x/plugin-packs.md
+++ b/docs/docs/v1.0.x/plugin-packs.md
@@ -55,7 +55,6 @@ The following plugin packs are developed by community members:
 - [ember-cli-deploy-aws-pack](https://github.com/kpfefferle/ember-cli-deploy-aws-pack)
 - [ember-cli-deploy-s3-pack](https://github.com/gaurav0/ember-cli-deploy-s3-pack)
 - [ember-cli-deploy-azure](https://github.com/duizendnegen/ember-cli-deploy-azure)
-- [ember-pagefront](https://github.com/pagefront/ember-pagefront)
 - [ember-cli-deploy-front-end-builds-pack](https://github.com/tedconf/ember-cli-deploy-front-end-builds-pack)
 
 ## Examples of Internal Company Plugin Packs


### PR DESCRIPTION
## What Changed & Why

I removed a reference to an Ember CLI plugin that uses a service that seems to no longer exist.

This service's homepage - https://www.pagefronthq.com/ - displays nothing, so it seems they're no longer around.  

I found this while searching for CloudFront-related items by searching for "front" on the page, so figured I'd take this opportunity to clean up the docs a little ☺️


## PR Checklist
- [ ] Add tests
- [ ] Add documentation
- [ ] Prefix documentation-only commits with [DOC]

