### PR TITLE
Fix plugin name extraction for scoped packages

### DIFF
--- a/lib/models/plugin-registry.js
+++ b/lib/models/plugin-registry.js
@@ -274,8 +274,8 @@ module.exports = CoreObject.extend({
 
   _pluginName: function(addon) {
     if(addon.name.indexOf('ember-cli-deploy') > -1) {
-      var pluginNameRegex = /^(ember-cli-deploy-)(.*)$/;
-      return addon.name.match(pluginNameRegex)[2];
+      var pluginNameRegex = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?(ember-cli-deploy-)(.*)$/;
+      return addon.name.match(pluginNameRegex)[3];
     }
     return addon.name;
   },

--- a/node-tests/unit/models/plugin-registry-test.js
+++ b/node-tests/unit/models/plugin-registry-test.js
@@ -92,22 +92,27 @@ describe('Plugin Registry', function() {
 
   it('accepts plugins with names not starting with ember-cli-deploy and renames those starting with', function() {
     var validPlugin = makePlugin('foo');
+
     var otherNamedPlugin = makePlugin('bar');
     otherNamedPlugin.name = 'my-other-bar';
+
+    var orgScopedPlugin = makePlugin('baz');
+    orgScopedPlugin.name = '@my-org/ember-cli-deploy-baz';
 
     var project = {
       name: function() {return 'test-project';},
       root: process.cwd(),
-      addons: [validPlugin, otherNamedPlugin],
+      addons: [validPlugin, otherNamedPlugin, orgScopedPlugin],
     };
 
     var registry = new PluginRegistry(project, mockUi, {});
 
     var plugins = registry.pluginInstances();
 
-    expect(plugins.length).to.equal(2);
+    expect(plugins.length).to.equal(3);
     expect(plugins[0].name).to.equal('foo');
     expect(plugins[1].name).to.equal('my-other-bar');
+    expect(plugins[2].name).to.equal('baz');
   });
 
   it('returns plugins for addons that have the correct keyword and implement the plugin function', function() {


### PR DESCRIPTION
## What Changed & Why

[The regex](https://github.com/ember-cli-deploy/ember-cli-deploy/pull/469/files#diff-14f392b737b5c71ccea9766c78ec6dbd9dd35fd1c02f61ad3915925b2e29eddeR277) introduced in #469 does not support scoped packages. This results in build failures with the error `TypeError: Cannot read property '2' of null`.

I have taken the new regex from https://www.npmjs.com/package/validate-npm-package-name

## PR Checklist
- [x] Add tests
- [ ] ~~Add documentation~~
- [ ] ~~Prefix documentation-only commits with [DOC]~~

## People
@duizendnegen @lukemelia 